### PR TITLE
Fix symmetry

### DIFF
--- a/moha/api.py
+++ b/moha/api.py
@@ -6,9 +6,9 @@ from typing import TextIO
 
 import numpy as np
 
-from scipy.sparse import csr_matrix, diags, lil_matrix
+from scipy.sparse import csr_matrix, lil_matrix
 
-from .utils import convert_indices
+from .utils import convert_indices, expand_sym
 
 
 __all__ = [
@@ -238,76 +238,3 @@ class HamiltonianAPI(ABC):
     def save(self, fname: str, integral, basis):
         r"""Save file as regular numpy array."""
         pass
-
-
-def expand_sym(sym, integral, nbody):
-    r"""
-    Restore permutational symmetry of one- and two-body terms.
-
-    :param integral: 2-D sparse array, the {one,two}-body integrals
-    :param sym: int, integral symmetry, one of 1 (no symmetry), 2, 4 or 8.
-    :param nbody: int, number of particle variables in the integral, one of 1 (one-body) or 2 (two-body)
-    :return: integral's matrix with a symmetry of 1
-
-    Notes
-    -----
-    Given the one- or two-body Hamiltonian matrix terms, :math:`h_{i,j}` and :math:`g_{ij,kl}` respectively,
-    the supported permutational symmetries are:
-    sym = 2:
-    :math:`h_{i,j} = h_{j,i}`
-    :math:`g_{ij,kl} = g_{kl,ij}`
-    sym = 4:
-    :math:`g_{ij,kl} = g_{kl,ij} = g_{ji,lk} = g_{lk,ji}`
-    sym = 8:
-    :math:`g_{ij,kl} = g_{kl,ij} = g_{ji,lk} = g_{lk,ji} = g_{kj,il} = g_(il,kj) = g_(li,jk) = g_(jk,li)`
-    sym = 1 corresponds to no-symmetry
-    where it is assumed the integrals are over real orbitals.
-
-    The input Hamiltonian terms are expected to be sparse arrays of dimensions :math:`(N,N)` or
-    :math:`(N^2, N^2)` for the one- and two-body integrals respectively. :math:`N` represents
-    the number of basis functions, which may be either of spatial or spin-orbital type.
-    This function applies to the input array the permutations indicated by the symmetry parameter `sym`
-    to adds the missing terms.
-    Phicisist notation is used for the two-body integrals: :math:`<pq|rs>` and further details of the
-    permutations considered can be found in [this site](http://vergil.chemistry.gatech.edu/notes/permsymm/permsymm.html).
-
-    """
-    if not sym in [1, 2, 4, 8]:
-        raise ValueError("Wrong input symmetry")
-    if not nbody in [1, 2]:
-        raise ValueError(f"`nbody` must be an integer, either 1 or 2, but {nbody} given")
-    if sym == 1:
-        return integral
-
-    # Expanding Symmetries
-    if nbody == 1:
-        if not sym == 2:
-            raise ValueError("Wrong 1-body term symmetry")
-        h_ii = diags(integral.diagonal()).copy()
-        integral = integral + integral.T - h_ii
-    else:
-        # getting nonzero elements from the 2d _sparse_ array
-        pq_array, rs_array = integral.nonzero()
-        n = int(np.sqrt(integral.shape[0]))
-
-        for pq, rs in zip(pq_array, rs_array):
-            p, q, r, s = convert_indices(n, int(pq), int(rs))
-            if sym >= 2:
-                # 1. Transpose: <pq|rs>=<rs|pq>
-                rs, pq = convert_indices(n, r, s, p, q)
-                integral[rs, pq] = integral[pq, rs]
-            if sym >= 4:
-                # 2. Permute dummy indices (swap variables of particles 1 and 2):
-                # <p_1 q_2|r_1 s_2> = <q_1 p_2|s_1 r_2>
-                qp, sr = convert_indices(n, q, p, s, r)
-                integral[qp, sr] = integral[pq, rs]
-                integral[sr, qp] = integral[rs, pq]
-            if sym == 8:
-                # 3. Permute orbitals of the same variable, e.g. <p_1 q_2|r_1 s_2> = <r_1 q_2|p_1 s_2>
-                rq, ps = convert_indices(n, r, q, p, s)
-                sp, qr = convert_indices(n, s, p, q, r)
-                integral[rq, ps] = integral[pq, rs]
-                integral[ps, rq] = integral[rs, pq]
-                integral[sp, qr] = integral[qp, sr]
-                integral[qr, sp] = integral[sr, qp]
-    return integral

--- a/moha/api.py
+++ b/moha/api.py
@@ -288,9 +288,10 @@ def expand_sym(sym, integral, nbody):
     else:
         # getting nonzero elements from the 2d _sparse_ array
         pq_array, rs_array = integral.nonzero()
+        n = int(np.sqrt(integral.shape[0]))
 
         for pq, rs in zip(pq_array, rs_array):
-            p, q, r, s = convert_indices(n, pq, rs)
+            p, q, r, s = convert_indices(n, int(pq), int(rs))
             if sym >= 2:
                 # 1. Transpose: <pq|rs>=<rs|pq>
                 rs, pq = convert_indices(n, r, s, p, q)

--- a/moha/hamiltonians.py
+++ b/moha/hamiltonians.py
@@ -4,9 +4,9 @@ import numpy as np
 
 from scipy.sparse import csr_matrix, diags, lil_matrix, hstack, vstack
 
-from .api import HamiltonianAPI, expand_sym
+from .api import HamiltonianAPI
 
-from .utils import get_atom_type, convert_indices
+from .utils import get_atom_type, convert_indices, expand_sym
 
 
 __all__ = [

--- a/moha/hamiltonians.py
+++ b/moha/hamiltonians.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from scipy.sparse import csr_matrix, diags, lil_matrix, hstack, vstack
 
-from .api import HamiltonianAPI
+from .api import HamiltonianAPI, expand_sym
 
 from .utils import get_atom_type, convert_indices
 
@@ -194,7 +194,7 @@ class HamPPP(HamiltonianAPI):
         else:
             raise TypeError("Wrong basis")
 
-        self.two_body = v
+        self.two_body = expand_sym(sym, v, 2)
         # return either sparse csr array (default) or dense N^2*N^2 array
         return self.to_dense(v, dim=4) if dense else v
 

--- a/moha/utils.py
+++ b/moha/utils.py
@@ -1,9 +1,14 @@
 r"""MoHa utilities submodule."""
 
+import numpy as np
+
+from scipy.sparse import diags
+
 
 __all__ = [
     "convert_indices",
     "get_atom_type",
+    "expand_sym",
 ]
 
 
@@ -60,3 +65,76 @@ def get_atom_type(atom):
         i += 1
     i -= 1
     return atom[:-i], int(atom[-i:])
+
+
+def expand_sym(sym, integral, nbody):
+    r"""
+    Restore permutational symmetry of one- and two-body terms.
+
+    :param integral: 2-D sparse array, the {one,two}-body integrals
+    :param sym: int, integral symmetry, one of 1 (no symmetry), 2, 4 or 8.
+    :param nbody: int, number of particle variables in the integral, one of 1 (one-body) or 2 (two-body)
+    :return: integral's matrix with a symmetry of 1
+
+    Notes
+    -----
+    Given the one- or two-body Hamiltonian matrix terms, :math:`h_{i,j}` and :math:`g_{ij,kl}` respectively,
+    the supported permutational symmetries are:
+    sym = 2:
+    :math:`h_{i,j} = h_{j,i}`
+    :math:`g_{ij,kl} = g_{kl,ij}`
+    sym = 4:
+    :math:`g_{ij,kl} = g_{kl,ij} = g_{ji,lk} = g_{lk,ji}`
+    sym = 8:
+    :math:`g_{ij,kl} = g_{kl,ij} = g_{ji,lk} = g_{lk,ji} = g_{kj,il} = g_(il,kj) = g_(li,jk) = g_(jk,li)`
+    sym = 1 corresponds to no-symmetry
+    where it is assumed the integrals are over real orbitals.
+
+    The input Hamiltonian terms are expected to be sparse arrays of dimensions :math:`(N,N)` or
+    :math:`(N^2, N^2)` for the one- and two-body integrals respectively. :math:`N` represents
+    the number of basis functions, which may be either of spatial or spin-orbital type.
+    This function applies to the input array the permutations indicated by the symmetry parameter `sym`
+    to adds the missing terms.
+    Phicisist notation is used for the two-body integrals: :math:`<pq|rs>` and further details of the
+    permutations considered can be found in [this site](http://vergil.chemistry.gatech.edu/notes/permsymm/permsymm.html).
+
+    """
+    if not sym in [1, 2, 4, 8]:
+        raise ValueError("Wrong input symmetry")
+    if not nbody in [1, 2]:
+        raise ValueError(f"`nbody` must be an integer, either 1 or 2, but {nbody} given")
+    if sym == 1:
+        return integral
+
+    # Expanding Symmetries
+    if nbody == 1:
+        if not sym == 2:
+            raise ValueError("Wrong 1-body term symmetry")
+        h_ii = diags(integral.diagonal()).copy()
+        integral = integral + integral.T - h_ii
+    else:
+        # getting nonzero elements from the 2d _sparse_ array
+        pq_array, rs_array = integral.nonzero()
+        n = int(np.sqrt(integral.shape[0]))
+
+        for pq, rs in zip(pq_array, rs_array):
+            p, q, r, s = convert_indices(n, int(pq), int(rs))
+            if sym >= 2:
+                # 1. Transpose: <pq|rs>=<rs|pq>
+                rs, pq = convert_indices(n, r, s, p, q)
+                integral[rs, pq] = integral[pq, rs]
+            if sym >= 4:
+                # 2. Permute dummy indices (swap variables of particles 1 and 2):
+                # <p_1 q_2|r_1 s_2> = <q_1 p_2|s_1 r_2>
+                qp, sr = convert_indices(n, q, p, s, r)
+                integral[qp, sr] = integral[pq, rs]
+                integral[sr, qp] = integral[rs, pq]
+            if sym == 8:
+                # 3. Permute orbitals of the same variable, e.g. <p_1 q_2|r_1 s_2> = <r_1 q_2|p_1 s_2>
+                rq, ps = convert_indices(n, r, q, p, s)
+                sp, qr = convert_indices(n, s, p, q, r)
+                integral[rq, ps] = integral[pq, rs]
+                integral[ps, rq] = integral[rs, pq]
+                integral[sp, qr] = integral[qp, sr]
+                integral[qr, sp] = integral[sr, qp]
+    return integral


### PR DESCRIPTION
Allowed symmetry of <pq|rs> terms in spin-orbital basis to be expanded

The symmetry of the <pq|rs> terms in spin-orbital basis was not being generated properly. Fixing this involved:
- adding a variable left undefined in the `expand_sym` function 
- passing the generated two-body sparse matrix through the symmetrization function before returning its value

Additionally,  `expand_sym`  was moved to the `utils` module