### PR TITLE
Heisenberg

### DIFF
--- a/moha/api.py
+++ b/moha/api.py
@@ -62,14 +62,12 @@ class HamiltonianAPI(ABC):
         pass
 
     @abstractmethod
-    def generate_one_body_integral(self, sym: int, basis: str, dense: bool):
+    def generate_one_body_integral(self, dense: bool, basis: str):
         r"""
         Generate one body integral in spatial or spin orbital basis.
 
         Parameters
         ----------
-        sym: int
-            symmetry -- [1, 2] default is 1
         basis: str
             ['spatial', 'spin orbital']
         dense: bool

--- a/moha/api.py
+++ b/moha/api.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from scipy.sparse import csr_matrix, lil_matrix
 
-from .utils import convert_indices
+from .utils import convert_indices, get_atom_type
 
 __all__ = [
     "HamiltonianAPI",
@@ -17,6 +17,44 @@ __all__ = [
 
 class HamiltonianAPI(ABC):
     r"""Hamiltonian abstract base class."""
+
+    def generate_connectivity_matrix(self):
+        r"""
+        Generate connectivity matrix.
+
+        Returns
+        -------
+        tuple
+            (dictionary, np.ndarray)
+        """
+        max_site = 0
+        atoms_sites_lst = []
+        for atom1, atom2, bond in self.connectivity:
+            atom1_name, site1 = get_atom_type(atom1)
+            atom2_name, site2 = get_atom_type(atom2)
+            for pair in [(atom1_name, site1), (atom2_name, site2)]:
+                if pair not in atoms_sites_lst:
+                    atoms_sites_lst.append(pair)
+            if max_site < max(site1, site2):  # finding the max index of site
+                max_site = max(site1, site2)
+        self.n_sites = len(atoms_sites_lst)
+
+        if self.atom_types is None:
+            atom_types = [None for i in range(max_site + 1)]
+            for atom, site in atoms_sites_lst:
+                atom_types[site] = atom
+            self.atom_types = atom_types
+        connectivity_mtrx = np.zeros((max_site, max_site))
+
+        for atom1, atom2, bond in self.connectivity:
+            atom1_name, site1 = get_atom_type(atom1)
+            atom2_name, site2 = get_atom_type(atom2)
+            connectivity_mtrx[site1 - 1, site2 - 1] = bond
+            # numbering of sites starts from 1
+
+        connectivity_mtrx = np.maximum(connectivity_mtrx, connectivity_mtrx.T)
+        self.connectivity_matrix = csr_matrix(connectivity_mtrx)
+        return atoms_sites_lst, self.connectivity_matrix
 
     @abstractmethod
     def generate_zero_body_integral(self):

--- a/moha/hamiltonians.py
+++ b/moha/hamiltonians.py
@@ -366,8 +366,9 @@ class HamHeisenberg(HamiltonianAPI):
                  J_ax: np.ndarray
                  ):
         r"""
-        Initialize XXZ Heisenberg Hamiltonian according to the formula:
+        Initialize XXZ Heisenberg Hamiltonian.
 
+        The form:
         :math:'\hat{H}_{X X Z}=\sum_p\left(\mu_p^Z-J_{p p}^{\mathrm{eq}}\right)
         S_p^Z+\sum_{p q} J_{p q}^{\mathrm{ax}} S_p^Z S_q^Z+\sum_{p q}
         J_{p q}^{\mathrm{eq}} S_p^{+} S_q^{-}'
@@ -391,7 +392,8 @@ class HamHeisenberg(HamiltonianAPI):
 
     def generate_zero_body_integral(self):
         """
-        Generate zero body term
+        Generate zero body term.
+
         Returns
         -------
         zero_energy: float
@@ -404,10 +406,36 @@ class HamHeisenberg(HamiltonianAPI):
                                    sym: int,
                                    dense: bool,
                                    basis='spinorbital'):
+        """
+        Generate one body integral.
+        
+        Parameters
+        ----------
+        sym
+        dense
+        basis
+
+        Returns
+        -------
+        None
+        """
         pass
 
     def generate_two_body_integral(self,
                                    sym: int,
                                    dense: bool,
                                    basis='spinorbital'):
+        """
+        Generate two body integral.
+
+        Parameters
+        ----------
+        sym
+        dense
+        basis
+
+        Returns
+        -------
+        None
+        """
         pass

--- a/moha/hamiltonians.py
+++ b/moha/hamiltonians.py
@@ -403,17 +403,15 @@ class HamHeisenberg(HamiltonianAPI):
         return zero_energy
 
     def generate_one_body_integral(self,
-                                   sym: int,
                                    dense: bool,
-                                   basis='spinorbital'):
+                                   basis='spin orbital'):
         r"""
         Generate one body integral.
 
         Parameters
         ----------
-        sym
-        dense
-        basis
+        dense: bool
+        basis: str
 
         Returns
         -------

--- a/moha/hamiltonians.py
+++ b/moha/hamiltonians.py
@@ -406,9 +406,9 @@ class HamHeisenberg(HamiltonianAPI):
                                    sym: int,
                                    dense: bool,
                                    basis='spinorbital'):
-        """
+        r"""
         Generate one body integral.
-        
+
         Parameters
         ----------
         sym

--- a/moha/hamiltonians.py
+++ b/moha/hamiltonians.py
@@ -365,13 +365,12 @@ class HamHeisenberg(HamiltonianAPI):
                  J_eq: np.ndarray,
                  J_ax: np.ndarray
                  ):
-        """
+        r"""
         Initialize XXZ Heisenberg Hamiltonian according to the formula:
-        $$
-        \hat{H}_{X X Z}=\sum_p\left(\mu_p^Z-J_{p p}^{\mathrm{eq}}\right)
-         S_p^Z+\sum_{p q} J_{p q}^{\mathrm{ax}} S_p^Z S_q^Z+\sum_{p q}
-          J_{p q}^{\mathrm{eq}} S_p^{+} S_q^{-}
-        $$
+
+        :math:'\hat{H}_{X X Z}=\sum_p\left(\mu_p^Z-J_{p p}^{\mathrm{eq}}\right)
+        S_p^Z+\sum_{p q} J_{p q}^{\mathrm{ax}} S_p^Z S_q^Z+\sum_{p q}
+        J_{p q}^{\mathrm{eq}} S_p^{+} S_q^{-}'
 
         Parameters
         ----------

--- a/moha/hamiltonians.py
+++ b/moha/hamiltonians.py
@@ -384,8 +384,12 @@ class HamHeisenberg(HamiltonianAPI):
         self.mu = np.array(mu)
         self.J_eq = J_eq
         self.J_ax = J_ax
-        self.atoms_num, self.connectivity_matrix = \
-            self.generate_connectivity_matrix()
+
+        # I live this commented till we decide whether we need
+        # to provide connectivity
+
+        # self.atoms_num, self.connectivity_matrix = \
+        #     self.generate_connectivity_matrix()
         self.zero_energy = None
         self.one_body = None
         self.two_body = None
@@ -415,9 +419,16 @@ class HamHeisenberg(HamiltonianAPI):
 
         Returns
         -------
-        None
+        scipy.sparse.csr_matrix or np.ndarray
         """
-        pass
+        if basis != 'spin orbital':
+            raise ValueError('Selected Hamiltonian supports'
+                             ' only spin orbital basis')
+        one_body_term = 0.5*diags(self.mu - np.diag(self.J_eq) -
+                                  np.sum(self.J_ax, axis=1),
+                                  format="csr")
+        self.one_body = one_body_term
+        return self.one_body.todense() if dense else self.one_body
 
     def generate_two_body_integral(self,
                                    sym: int,

--- a/moha/hamiltonians.py
+++ b/moha/hamiltonians.py
@@ -385,9 +385,19 @@ class HamHeisenberg(HamiltonianAPI):
         self.J_ax = J_ax
         self.atoms_num, self.connectivity_matrix = \
             self.generate_connectivity_matrix()
+        self.zero_energy = None
+        self.one_body = None
+        self.two_body = None
 
     def generate_zero_body_integral(self):
-        pass
+        """
+        Generate zero body term
+        Returns
+        -------
+        zero_energy: float
+        """
+        zero_energy = -0.5*np.sum(self.mu-np.diag(self.J_eq)) + 0.25*np.sum(self.J_ax)
+        return zero_energy
 
     def generate_one_body_integral(self, sym: int, dense: bool, basis='spinorbital'):
         pass

--- a/moha/hamiltonians.py
+++ b/moha/hamiltonians.py
@@ -106,7 +106,7 @@ class HamPPP(HamiltonianAPI):
         if self.charges is None or self.gamma is None:
             return 0
         else:
-            self.zero_energy = 0.5*self.charges@self.gamma@self.charges
+            self.zero_energy = 0.5 * self.charges @ self.gamma @ self.charges
         return self.zero_energy
 
     def generate_one_body_integral(self, basis: str, dense: bool):
@@ -200,20 +200,20 @@ class HamPPP(HamiltonianAPI):
                 for q in range(n_sp):
                     if p != q:
                         i, j = convert_indices(Nv, p, q, p, q)
-                        v[i, j] = 0.5*gamma[p, q]
+                        v[i, j] = 0.5 * gamma[p, q]
 
                         i, j = convert_indices(Nv, p, q + n_sp, p, q + n_sp)
-                        v[i, j] = 0.5*gamma[p, q + n_sp]
+                        v[i, j] = 0.5 * gamma[p, q + n_sp]
 
                         i, j = convert_indices(Nv, p + n_sp, q, p + n_sp, q)
-                        v[i, j] = 0.5*gamma[p + n_sp, q]
+                        v[i, j] = 0.5 * gamma[p + n_sp, q]
 
                         i, j = convert_indices(Nv,
                                                p + n_sp,
                                                q + n_sp,
                                                p + n_sp,
                                                q + n_sp)
-                        v[i, j] = 0.5*gamma[p + n_sp, q + n_sp]
+                        v[i, j] = 0.5 * gamma[p + n_sp, q + n_sp]
 
         v = v.tocsr()
         self.two_body = expand_sym(sym, v, 2)
@@ -368,8 +368,9 @@ class HamHeisenberg(HamiltonianAPI):
         """
         Initialize XXZ Heisenberg Hamiltonian according to the formula:
         $$
-        \hat{H}_{X X Z}=\sum_p\left(\mu_p^Z-J_{p p}^{\mathrm{eq}}\right) S_p^Z+
-        \sum_{p q} J_{p q}^{\mathrm{ax}} S_p^Z S_q^Z+\sum_{p q} J_{p q}^{\mathrm{eq}} S_p^{+} S_q^{-}
+        \hat{H}_{X X Z}=\sum_p\left(\mu_p^Z-J_{p p}^{\mathrm{eq}}\right)
+         S_p^Z+\sum_{p q} J_{p q}^{\mathrm{ax}} S_p^Z S_q^Z+\sum_{p q}
+          J_{p q}^{\mathrm{eq}} S_p^{+} S_q^{-}
         $$
 
         Parameters
@@ -396,11 +397,18 @@ class HamHeisenberg(HamiltonianAPI):
         -------
         zero_energy: float
         """
-        zero_energy = -0.5*np.sum(self.mu-np.diag(self.J_eq)) + 0.25*np.sum(self.J_ax)
+        zero_energy = -0.5 * np.sum(self.mu - np.diag(self.J_eq)) \
+            + 0.25 * np.sum(self.J_ax)
         return zero_energy
 
-    def generate_one_body_integral(self, sym: int, dense: bool, basis='spinorbital'):
+    def generate_one_body_integral(self,
+                                   sym: int,
+                                   dense: bool,
+                                   basis='spinorbital'):
         pass
 
-    def generate_two_body_integral(self, sym: int, dense: bool, basis='spinorbital'):
+    def generate_two_body_integral(self,
+                                   sym: int,
+                                   dense: bool,
+                                   basis='spinorbital'):
         pass

--- a/moha/hamiltonians.py
+++ b/moha/hamiltonians.py
@@ -395,3 +395,22 @@ class HamHuck(HamHub):
             Bz=Bz,
         )
         self.charges = np.zeros(self.n_sites)
+
+
+class HamHeisenberg(HamiltonianAPI):
+    def __init__(self,
+                 connectivity: list,
+                 mu: list,
+                 J_eq: np.ndarray,
+                 J_ax: np.ndarray
+                 ):
+        pass
+
+    def generate_zero_body_integral(self):
+        pass
+
+    def generate_one_body_integral(self, sym: int, basis: str, dense: bool):
+        pass
+
+    def generate_two_body_integral(self, sym: int, basis: str, dense: bool):
+        pass


### PR DESCRIPTION
Created a blueprint for Heisenberg Hamiltonian and updated zero body term.

@PaulWAyers @gabrielasd I created the initialization based on connectivity matrix, but I'm not sure if we need it in case of Heisenberg model. 
In case of PPP+ hamiltonian it was necessary because Huckel Hamiltonian is build based on the connectivity. However in this case it seems like there is no explicit dependency on connectivity unless I'm missing something.

As far as I know, the Heisenberg model using the connectivity, but it seems like if user provides $J ^{ax}$ there is no need to use provide a connectivity