### PR TITLE
fixed spinorbital to spatial conversion

### DIFF
--- a/moha/api.py
+++ b/moha/api.py
@@ -227,6 +227,11 @@ class HamiltonianAPI(ABC):
                                                p, p + self.n_sites,
                                                q, q + self.n_sites)
                     spatial_int[pp, qq] = integral[pp_, qq_]
+
+                    p_q, p_q = convert_indices(n,
+                                               p+self.n_sites, q,
+                                               p+self.n_sites, q)
+                    spatial_int[pq, pq] += integral[p_q, p_q]
         else:
             raise ValueError("Wrong integral input.")
         spatial_int = expand_sym(sym, spatial_int, nbody)


### PR DESCRIPTION
@gabrielasd @PaulWAyers 
It seems like during the conversion from spin orbital to spatial orbital not all elements were taken into account. Specifically, in Heisenberg model there is a term [p_, q, p_, q] (where underscore means spin down). However, there is no such term in PPP Hamiltonian, so I added it to the conversion so this still can be a method in a parent class.