### PR TITLE
Heisenberg

### DIFF
--- a/examples/Ising.ipynb
+++ b/examples/Ising.ipynb
@@ -1,0 +1,511 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Testing Ising model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "# import matplotlib.pyplot as plt\n",
+    "from pyscf import fci"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Building XXX Heisenberg model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "FCI energy for 2:  -1.2782119259115534 ; error:  -0.8350647453516081\n",
+      "FCI energy for 4:  -0.5629897290600718 ; error:  -0.11984254850012654\n",
+      "FCI energy for 6:  -0.546112176636998 ; error:  -0.10296499607705267\n"
+     ]
+    }
+   ],
+   "source": [
+    "def generate_inds(value, p, q, r, s):\n",
+    "    \"\"\"\n",
+    "    Generate all the indices for the 4 different terms in the 2-body hamiltonian\n",
+    "    \"\"\"\n",
+    "    res = []\n",
+    "    res.append((value, p, q, r, s))\n",
+    "    res.append((value, r, s, p, q))\n",
+    "    # res.append((-value, p, s, r, q))\n",
+    "    # res.append((-value, r, q, p, s))\n",
+    "\n",
+    "    res.append((value, p, q, s, r))\n",
+    "    res.append((value, q, p, r, s))\n",
+    "    res.append((value, q, p, s, r))\n",
+    "\n",
+    "    # permutation symmetries\n",
+    "    res.append((value, s, r, p, q))\n",
+    "    res.append((value, r, s, q, p))\n",
+    "    res.append((value, s, r, q, p))\n",
+    "\n",
+    "\n",
+    "    return res\n",
+    "\n",
+    "for n_sites in range(2, 8, 2):\n",
+    "\n",
+    "    J_xy = 1\n",
+    "    J_z = 1\n",
+    "    h = np.zeros((2*n_sites, 2*n_sites))\n",
+    "    v = np.zeros((2*n_sites, 2*n_sites, 2*n_sites, 2*n_sites))\n",
+    "\n",
+    "    for i in range(n_sites):\n",
+    "        j = i+1\n",
+    "        if j == n_sites:\n",
+    "            j = 0\n",
+    "\n",
+    "        h[i, i] += -J_z/4\n",
+    "        h[j, j] += -J_z/4 \n",
+    "        h[i+n_sites, i+n_sites] += -J_z/4\n",
+    "        h[j+n_sites, j+n_sites] += -J_z/4\n",
+    "\n",
+    "    # populating 2body terms\n",
+    "        \n",
+    "    for i in range(n_sites):\n",
+    "        j = i+1\n",
+    "        if j == n_sites:\n",
+    "            j = 0\n",
+    "\n",
+    "        values = generate_inds(J_z/4, j, j, i, i)\n",
+    "        for value, p, q, r, s in values:\n",
+    "            v[p, q, r, s] += value\n",
+    "        \n",
+    "\n",
+    "        values = generate_inds(J_z/4, j, j, i+n_sites, i+n_sites)\n",
+    "        for value, p, q, r, s in values:\n",
+    "            v[p, q, r, s] += value\n",
+    "    \n",
+    "        values = generate_inds(J_z/4, j+n_sites, j+n_sites, i, i)\n",
+    "        for value, p, q, r, s in values:\n",
+    "            v[p, q, r, s] += value\n",
+    "\n",
+    "        values = generate_inds(J_z/4, j+n_sites, j+n_sites, i+n_sites, i+n_sites)\n",
+    "        for value, p, q, r, s in values:\n",
+    "            v[p, q, r, s] += value\n",
+    "\n",
+    "        values = generate_inds(J_xy/2, j, i, j+n_sites, i+n_sites)\n",
+    "        for value, p, q, r, s in values:\n",
+    "            v[p, q, r, s] += value\n",
+    "\n",
+    "        values = generate_inds(J_xy/2, i, j, i+n_sites, j+n_sites)\n",
+    "        for value, p, q, r, s in values:\n",
+    "            v[p, q, r, s] += value\n",
+    "\n",
+    "\n",
+    "    e_0 = J_z/4*n_sites\n",
+    "\n",
+    "    # solve fullci problem\n",
+    "    e, fcivec = fci.direct_spin0.kernel(1*h, 1*v, 2*n_sites, 2*n_sites, nroots=1,\n",
+    "                                        max_memory=10000)\n",
+    "    e_exact = 0.25-np.log(2)\n",
+    "    print(f\"FCI energy for {n_sites}: \", (e+e_0)/(2*n_sites), \"; error: \", (e+e_0)/(2*n_sites)-e_exact)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ground state energy: -0.43684286095118124\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "from scipy.linalg import eigh\n",
+    "\n",
+    "# Define Pauli spin matrices\n",
+    "sigma_x = np.array([[0, 1], [1, 0]])\n",
+    "sigma_y = np.array([[0, -1j], [1j, 0]])\n",
+    "sigma_z = np.array([[1, 0], [0, -1]])\n",
+    "I = np.array([[1, 0], [0, 1]])\n",
+    "\n",
+    "# Define function for Kronecker product with identity\n",
+    "def kron_id(matrix, N, L):\n",
+    "  \"\"\"\n",
+    "  Creates Kronecker product of matrix with identity matrices.\n",
+    "\n",
+    "  Args:\n",
+    "      matrix: The matrix for Kronecker product.\n",
+    "      N: Number of identity matrices before the matrix.\n",
+    "      L: Number of sites.\n",
+    "\n",
+    "  Returns:\n",
+    "      A Kronecker product of the matrix with identity matrices.\n",
+    "  \"\"\"\n",
+    "  result = matrix\n",
+    "  for _ in range(N):\n",
+    "    result = np.kron(I, result)\n",
+    "\n",
+    "  for _ in range(L-N-1):\n",
+    "    result = np.kron(result, I)\n",
+    "  return 1/2*result\n",
+    "\n",
+    "# Define function to create spin operators on Nth site\n",
+    "def spin_operator(operator, N, L):\n",
+    "  \"\"\"\n",
+    "  Creates a spin operator (Sx, Sy, Sz) on the Nth site.\n",
+    "\n",
+    "  Args:\n",
+    "      operator: The Pauli spin matrix (sigma_x, sigma_y, sigma_z).\n",
+    "      N: The site index for the spin operator.\n",
+    "      L: Total number of sites.\n",
+    "\n",
+    "  Returns:\n",
+    "      A Kronecker product representing the spin operator on Nth site.\n",
+    "  \"\"\"\n",
+    "  return kron_id(operator, N, L)\n",
+    "\n",
+    "# Define system size (number of sites)\n",
+    "L = 6 # Change this for different system size\n",
+    "\n",
+    "# Create spin operators on each site\n",
+    "Sx = [spin_operator(sigma_x, i, L) for i in range(L)]\n",
+    "Sy = [spin_operator(sigma_y, i, L) for i in range(L)]\n",
+    "Sz = [spin_operator(sigma_z, i, L) for i in range(L)]\n",
+    "\n",
+    "# Define Hamiltonian (only nearest-neighbor interaction for simplicity)\n",
+    "J = 1  # Coupling constant\n",
+    "delta = 0.8\n",
+    "H = 0\n",
+    "for i in range(L):\n",
+    "    j = i+1\n",
+    "    if j == L:\n",
+    "        j = 0\n",
+    "    H += J * (Sx[i] @ Sx[j] + Sy[i] @ Sy[j] + delta*Sz[i] @ Sz[j])\n",
+    "\n",
+    "# Convert symbolic Hamiltonian to numpy array\n",
+    "H_array = np.array(H, dtype=complex)\n",
+    "\n",
+    "# Calculate eigenvalues and ground state\n",
+    "eigenvalues, eigenvectors = eigh(H_array)\n",
+    "\n",
+    "# Print ground state energy (lowest eigenvalue)\n",
+    "print(f\"Ground state energy: {eigenvalues[0]/L}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[0. , 0. , 0.5, 0. , 0. , 0. , 0. , 0. ],\n",
+       "       [0. , 0. , 0. , 0.5, 0. , 0. , 0. , 0. ],\n",
+       "       [0.5, 0. , 0. , 0. , 0. , 0. , 0. , 0. ],\n",
+       "       [0. , 0.5, 0. , 0. , 0. , 0. , 0. , 0. ],\n",
+       "       [0. , 0. , 0. , 0. , 0. , 0. , 0.5, 0. ],\n",
+       "       [0. , 0. , 0. , 0. , 0. , 0. , 0. , 0.5],\n",
+       "       [0. , 0. , 0. , 0. , 0.5, 0. , 0. , 0. ],\n",
+       "       [0. , 0. , 0. , 0. , 0. , 0.5, 0. , 0. ]])"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Sx[1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[0, 1, 0, 0],\n",
+       "       [1, 0, 0, 0],\n",
+       "       [0, 0, 0, 1],\n",
+       "       [0, 0, 1, 0]])"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.kron(I, sigma_x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.collections.PathCollection at 0x7fc378d09220>"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAD4CAYAAADhNOGaAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/MnkTPAAAACXBIWXMAAAsTAAALEwEAmpwYAAASyElEQVR4nO3db4xdd33n8fencRCOl8hOsd1xsqwBRa5WrXDSEVsaKRJrm2xcFJtKlYJEZFWVzIPCAiulcton9MnWImVpH0UyAdYSNCua5p9SK4ljitg+2FTj2I1dnMiChhB7sKeRXLZgiTT99oHP0MnkjmfunBlfT37vl3R0zvmd3++c74kz9zP3d++dm6pCktSuXxh1AZKk0TIIJKlxBoEkNc4gkKTGGQSS1LhVoy5gMd797nfX5s2bR12GJK0oR48e/ceqWj+7fUUGwebNm5mYmBh1GZK0oiT5waD2XlNDSW5IcjjJ6W697jJ9r0lyLMmTM9o+n+RMkuPdsrNPPZKk4fV9jWAfcKSqbgaOdPtz+QxwakD7l6pqa7cc6lmPJGlIfYNgF3Cw2z4I7B7UKclNwG8CD/a8niRpifUNgo1VNQnQrTfM0e9Pgd8H/nXAsU8leSHJV+eZWtqbZCLJxNTUVM+yJUnT5g2CJM8mOTlg2bWQCyT5KHC+qo4OOPwA8H5gKzAJfHGu81TVgaoar6rx9evf8qK3JGmR5n3XUFVtn+tYknNJxqpqMskYcH5At9uAu7oXgt8JXJ/k61X1iao6N+NcXwaeHDBekpr32LEz3P/0S5y9cJFNa1dz7x1b2H3LjUty7r5TQ08Ae7rtPcDjsztU1X1VdVNVbQbuBr5VVZ8A6MJj2seAkz3rkdTTY8fOcNv+b/HefX/Fbfu/xWPHzoy6pOY9duwM9z1ygjMXLlLAmQsXue+RE0v2b9M3CPYDO5KcBnZ0+yTZlGQh7wD6QpITSV4APgx8rmc9knpY7gccLc79T7/ExdffeFPbxdff4P6nX1qS8/f6QFlVvQZsG9B+FnjLZwKq6tvAt2fs39Pn+pKW1uUecJZqGkLDO3vh4lDtw/JvDUn6ueV+wNHibFq7eqj2YRkEGinno68uy/2Ao8W5944trL72mje1rb72Gu69Y8uSnN8g0Mg4H331We4HHC3O7ltu5I9/61e5ce1qAty4djV//Fu/umTTdSvyj87p7cH56KvP9H/35XqbohZv9y03Ltu/g0GgkXE++uq0nA84ujo5NaSRcT5aujoYBBoZ56Olq4NTQxoZ56Olq4NBoJFyPloaPaeGJKlxBoEkNc4gkKTGGQSS1DiDQJIaZxBIUuMMAklqnEEgSY0zCCSpcb2CIMkNSQ4nOd2t183R7+Xuu4mPJ5kYdrwkafn0fUawDzhSVTcDR7r9uXy4qrZW1fgix0uSlkHfINgFHOy2DwK7r/B4SVJPfYNgY1VNAnTrDXP0K+CZJEeT7F3EeJLsTTKRZGJqaqpn2ZKkafP+9dEkzwK/NODQHw5xnduq6mySDcDhJC9W1XeGGE9VHQAOAIyPj9cwYyVJc5s3CKpq+1zHkpxLMlZVk0nGgPNznONstz6f5FHgg8B3gAWNlyQtn75TQ08Ae7rtPcDjszskWZPkXdPbwEeAkwsdL0laXn2DYD+wI8lpYEe3T5JNSQ51fTYCf5Pk74C/Bf6qqp663HhJ0pXT6xvKquo1YNuA9rPAzm77+8AHhhkvSbpy/GSxJDXOIJCkxhkEktQ4g0CSGmcQSFLjDAJJapxBIEmNMwgkqXEGgSQ1ziCQpMYZBJLUOINAkhpnEEhS4wwCSWqcQSBJjTMIJKlxBoEkNc4gkKTG9QqCJDckOZzkdLdeN0e/l5OcSHI8ycSM9s8nOdO1H0+ys089kqTh9X1GsA84UlU3A0e6/bl8uKq2VtX4rPYvde1bq+rQwJGSpGXTNwh2AQe77YPA7p7nkyRdYX2DYGNVTQJ06w1z9CvgmSRHk+yddexTSV5I8tW5ppYAkuxNMpFkYmpqqmfZkqRp8wZBkmeTnByw7BriOrdV1a3AncDvJbm9a38AeD+wFZgEvjjXCarqQFWNV9X4+vXrh7i0JOlyVs3Xoaq2z3UsybkkY1U1mWQMOD/HOc526/NJHgU+CHynqs7NONeXgSeHvQFJUj99p4aeAPZ023uAx2d3SLImybumt4GPACe7/bEZXT823S5JunLmfUYwj/3AN5P8LvAK8NsASTYBD1bVTmAj8GiS6ev9eVU91Y3/QpKtXHoN4WXgkz3rkSQNqVcQVNVrwLYB7WeBnd3294EPzDH+nj7XlyT15yeLJalxBoEkNc4gkKTGGQSS1DiDQJIaZxBIUuMMAklqnEEgSY0zCCSpcQaBJDXOIJCkxhkEktQ4g0CSGmcQSFLjDAJJapxBIEmNMwgkqXEGgSQ1rlcQJLkhyeEkp7v1ujn6rU3ycJIXk5xK8qFhxkuSlk/fZwT7gCNVdTNwpNsf5M+Ap6rql7n0/cWnhhwvSVomfYNgF3Cw2z4I7J7dIcn1wO3AVwCq6mdVdWGh4yVJy6tvEGysqkmAbr1hQJ/3AVPA15IcS/JgkjVDjAcgyd4kE0kmpqamepYtSZo2bxAkeTbJyQHLrgVeYxVwK/BAVd0C/IRFTAFV1YGqGq+q8fXr1w87XJI0h1Xzdaiq7XMdS3IuyVhVTSYZA84P6PYq8GpVPdftP8y/B8FCxkuSllHfqaEngD3d9h7g8dkdqupHwA+TbOmatgHfXeh4SdLy6hsE+4EdSU4DO7p9kmxKcmhGv08D30jyArAV+J+XGy9JunLmnRq6nKp6jUu/4c9uPwvsnLF/HBhf6HhJ0pXjJ4slqXEGgSQ1ziCQpMYZBJLUOINAkhpnEEhS4wwCSWqcQSBJjTMIJKlxBoEkNc4gkKTGGQSS1DiDQJIaZxBIUuMMAklqnEEgSY0zCCSpcQaBJDWuVxAkuSHJ4SSnu/W6OfqtTfJwkheTnEryoa7980nOJDneLTsHjZckLZ++zwj2AUeq6mbgSLc/yJ8BT1XVLwMfAE7NOPalqtraLYcGD5ckLZe+QbALONhtHwR2z+6Q5HrgduArAFX1s6q60PO6kqQl0jcINlbVJEC33jCgz/uAKeBrSY4leTDJmhnHP5XkhSRfnWtqCSDJ3iQTSSampqZ6li1JmjZvECR5NsnJAcuuBV5jFXAr8EBV3QL8hH+fQnoAeD+wFZgEvjjXSarqQFWNV9X4+vXrF3hpSdJ8Vs3Xoaq2z3UsybkkY1U1mWQMOD+g26vAq1X1XLf/MF0QVNW5Gef6MvDkMMVLkvrrOzX0BLCn294DPD67Q1X9CPhhki1d0zbguwBdeEz7GHCyZz2SpCHN+4xgHvuBbyb5XeAV4LcBkmwCHqyq6beDfhr4RpJ3AN8Hfqdr/0KSrUABLwOf7FmPJGlIvYKgql7j0m/4s9vPAjtn7B8Hxgf0u6fP9SVJ/fnJYklqnEEgSY0zCCSpcQaBJDXOIJCkxhkEktQ4g0CSGmcQSFLjDAJJapxBIEmNMwgkqXEGgSQ1ziCQpMYZBJLUOINAkhpnEEhS4wwCSWpcryBIckOSw0lOd+t1A/psSXJ8xvLjJJ9d6HhJ0vLq+4xgH3Ckqm4GjnT7b1JVL1XV1qraCvwa8FPg0YWOlyQtr75BsAs42G0fBHbP038b8L2q+sEix0uSlljfINhYVZMA3XrDPP3vBh7qMV6StMRWzdchybPALw049IfDXCjJO4C7gPuGGTdj/F5gL8B73vOexZxCkjTAvEFQVdvnOpbkXJKxqppMMgacv8yp7gSer6pzM9oWPL6qDgAHAMbHx2u+uiVJC9N3augJYE+3vQd4/DJ9P86bp4WGHS9JWgZ9g2A/sCPJaWBHt0+STUkOTXdKcl13/JGFjJckXTnzTg1dTlW9xqV3As1uPwvsnLH/U+AXFzpeknTl+MliSWqcQSBJjTMIJKlxBoEkNc4gkKTGGQSS1DiDQJIaZxBIUuMMAklqnEEgSY0zCCSpcQaBJDXOIJCkxhkEktQ4g0CSGmcQSFLjDAJJapxBIEmN6xUESW5IcjjJ6W69bkCfLUmOz1h+nOSz3bHPJzkz49jOt1xEkrSs+j4j2AccqaqbgSPd/ptU1UtVtbWqtgK/BvwUeHRGly9NH6+qQ7PHS5KWV98g2AUc7LYPArvn6b8N+F5V/aDndSVJS6RvEGysqkmAbr1hnv53Aw/NavtUkheSfHXQ1JIkaXnNGwRJnk1ycsCya5gLJXkHcBfwFzOaHwDeD2wFJoEvXmb83iQTSSampqaGubQk6TJWzdehqrbPdSzJuSRjVTWZZAw4f5lT3Qk8X1XnZpz759tJvgw8eZk6DgAHAMbHx2u+uiVJC9N3augJYE+3vQd4/DJ9P86saaEuPKZ9DDjZsx5J0pD6BsF+YEeS08CObp8km5L8/B1ASa7rjj8ya/wXkpxI8gLwYeBzPeuRJA1p3qmhy6mq17j0TqDZ7WeBnTP2fwr84oB+9/S5viSpPz9ZLEmNMwgkqXEGgSQ1ziCQpMYZBJLUOINAkhpnEEhS4wwCSWqcQSBJjTMIJKlxBoEkNc4gkKTGGQSS1DiDQJIaZxBIUuMMAklqnEEgSY0zCCSpcb2CIMkNSQ4nOd2t183R73NJ/j7JySQPJXnnMOMlScun7zOCfcCRqroZONLtv0mSG4H/DoxX1a8A1wB3L3S8JGl59Q2CXcDBbvsgsHuOfquA1UlWAdcBZ4ccL0laJn2DYGNVTQJ06w2zO1TVGeBPgFeASeCfquqZhY6XJC2veYMgybPd3P7sZddCLtDN++8C3gtsAtYk+cSwhSbZm2QiycTU1NSwwyVJc1g1X4eq2j7XsSTnkoxV1WSSMeD8gG7bgX+oqqluzCPAbwBfBxYyfrqOA8ABgPHx8ZqvbknSwvSdGnoC2NNt7wEeH9DnFeDXk1yXJMA24NQQ4yVJy6hvEOwHdiQ5Dezo9kmyKckhgKp6DngYeB440V3zwOXGS5KunFStvFmW8fHxmpiYGHUZkrSiJDlaVeOz2/1ksSQ1ziCQpMYZBJLUOINAkhpnEEhS4wwCSWrcvJ8sfrt47NgZ7n/6Jc5euMimtau5944t7L7lxlGXJUkj10QQPHbsDPc9coKLr78BwJkLF7nvkRMAhoGk5jUxNXT/0y/9PASmXXz9De5/+qURVSRJV48mguDshYtDtUtSS5oIgk1rVw/VLkktaSII7r1jC6uvveZNbauvvYZ779gyoook6erRxIvF0y8I+64hSXqrJoIALoWBD/yS9FZNTA1JkuZmEEhS4wwCSWqcQSBJjTMIJKlxK/I7i5NMAT9Y5PB3A/+4hOWMkvdy9Xm73Ad4L1erPvfyn6pq/ezGFRkEfSSZGPTlzSuR93L1ebvcB3gvV6vluBenhiSpcQaBJDWuxSA4MOoClpD3cvV5u9wHeC9XqyW/l+ZeI5AkvVmLzwgkSTMYBJLUuGaCIMl/TPLXSU4l+fsknxl1TYuR5J1J/jbJ33X38UejrqmvJNckOZbkyVHX0keSl5OcSHI8ycSo6+kjydokDyd5sfuZ+dCoaxpWki3dv8X08uMknx11XYuV5HPdz/zJJA8leeeSnbuV1wiSjAFjVfV8kncBR4HdVfXdEZc2lCQB1lTVPye5Fvgb4DNV9f9GXNqiJfkfwDhwfVV9dNT1LFaSl4HxqlrxH1xKchD4v1X1YJJ3ANdV1YURl7VoSa4BzgD/paoW+2HUkUlyI5d+1v9zVV1M8k3gUFX976U4fzPPCKpqsqqe77b/P3AKWHFfUFCX/HO3e223rNg0T3IT8JvAg6OuRZckuR64HfgKQFX9bCWHQGcb8L2VGAIzrAJWJ1kFXAecXaoTNxMEMyXZDNwCPDfiUhalm0o5DpwHDlfViryPzp8Cvw/864jrWAoFPJPkaJK9oy6mh/cBU8DXuim7B5OsGXVRPd0NPDTqIharqs4AfwK8AkwC/1RVzyzV+ZsLgiT/AfhL4LNV9eNR17MYVfVGVW0FbgI+mORXRlzSoiT5KHC+qo6OupYlcltV3QrcCfxekttHXdAirQJuBR6oqluAnwD7RlvS4nVTW3cBfzHqWhYryTpgF/BeYBOwJsknlur8TQVBN6f+l8A3quqRUdfTV/d0/dvAfxttJYt2G3BXN7f+f4D/muTroy1p8arqbLc+DzwKfHC0FS3aq8CrM55pPsylYFip7gSer6pzoy6kh+3AP1TVVFW9DjwC/MZSnbyZIOheZP0KcKqq/teo61msJOuTrO22V3Ppf5AXR1rUIlXVfVV1U1Vt5tJT929V1ZL9lnMlJVnTvQmBbhrlI8DJ0Va1OFX1I+CHSbZ0TduAFfWmilk+zgqeFuq8Avx6kuu6x7JtXHqdc0k08+X1XPrt8x7gRDe/DvAHVXVodCUtyhhwsHsXxC8A36yqFf22y7eJjcCjl35GWQX8eVU9NdqSevk08I1uWuX7wO+MuJ5FSXIdsAP45Khr6aOqnkvyMPA88C/AMZbwT0008/ZRSdJgzUwNSZIGMwgkqXEGgSQ1ziCQpMYZBJLUOINAkhpnEEhS4/4N9OIi3pWa06wAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "fci_energies = [-0.8266059629557765, -0.46899486453003214, -0.4605560883183338, -0.4600550476827342]\n",
+    "fci_energies_array = np.array(fci_energies)\n",
+    "\n",
+    "e_exact = 0.25-np.log(2)\n",
+    "plt.scatter(np.arange(2, 10, 2), fci_energies_array, label='FCI')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXwAAAD4CAYAAADvsV2wAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/MnkTPAAAACXBIWXMAAAsTAAALEwEAmpwYAAALl0lEQVR4nO3dX4id+V3H8c/X2SwObZ2ACbrJ7hrLSkAFzbIsWxZK8V+qNnYvvFhBhVoJFRVFiDReCF71IiDFP1hCq7bYWsqaht1laxRUvNHabFNN6zayLFs2SWXbQqb+GTCNPy9yss6eziRnZk7meWZ+rxcMe+Z5fpPz5bcn7519zpkz1VoLALvftww9AADbQ/ABOiH4AJ0QfIBOCD5AJ+4ZeoDb2bdvXzt06NDQYwDsGM8///xXW2v71zo36uAfOnQo58+fH3oMgB2jqr603jmXdAA6IfgAnRB8gE4IPkAnBB+gE6N+lc5mnL1wJafOXcrVays5sHcxJ44ezhNHDg49FsDgRhn8qjqW5NhDDz20oa87e+FKTp65mJXrN5IkV66t5OSZi0ki+kD3RnlJp7X2TGvt+NLS0oa+7tS5S6/F/paV6zdy6tyleY4HsCONMvibdfXayoaOA/RkVwX/wN7FDR0H6MmuCv6Jo4ezuGfhdccW9yzkxNHDA00EMB6jfNJ2s249MetVOgDfbFcFP7kZfYEH+Ga76pIOAOsTfIBOCD5AJwQfoBOCD9AJwQfohOADdELwAToh+ACdEHyATgg+QCdGGfyqOlZVp5eXl4ceBWDXGGXwN/sbrwBY3yiDD8D8CT5AJwQfoBOCD9AJwQfohOADdELwAToh+ACdEHyATgg+QCcEH6ATgg/QCcEH6ITgA3RC8AE6IfgAnRB8gE4IPkAnBB+gE4IP0AnBB+iE4AN0QvABOiH4AJ0YZfCr6lhVnV5eXh56FIBdY5TBb60901o7vrS0NPQoALvGKIMPwPwJPkAnBB+gE4IP0AnBB+iE4AN0QvABOiH4AJ0QfIBOCD5AJwQfoBOCD9AJwQfohOADdELwAToh+ACdEHyATgg+QCcEH6ATgg/QCcEH6ITgA3RC8AE6IfgAnRB8gE4IPkAnBB+gE4IP0AnBB+iE4AN0QvABOiH4AJ0QfIBOCD5AJwQfoBOCD9AJwQfohOADdELwATqxbcGvqjdX1Yeq6qntuk8A/t9Mwa+qP66qV6vq81PH315Vl6rqxap67+3+jNbaS621d29lWAA2754Z1/1pkj9I8pFbB6pqIckfJvnRJJeTfKaqnk6ykOR9U1//C621V7c8LQCbNlPwW2t/X1WHpg4/muTF1tpLSVJVH0/yztba+5K8Y7MDVdXxJMeT5MEHH9zsHwPAlK1cwz+Y5JVVn1+eHFtTVX17VX0gyZGqOrneutba6dbaI621R/bv37+F8QBYbdZLOmupNY619Ra31r6W5D1buD8AtmAr3+FfTvLAqs/vT3J1a+MAcLdsJfifSfI9VfXdVXVvkieTPD2fsQCYt1lflvnnSf4hyeGqulxV726tfSPJryQ5l+SFJJ9orX3h7o0KwFbM+iqdn1nn+HNJnpvrRADcFaN8a4WqOlZVp5eXl4ceBWDXGGXwW2vPtNaOLy0tDT0KwK4xyuADMH+CD9AJwQfohOADdELwAToxyuB7WSbA/I0y+F6WCTB/oww+APMn+ACdEHyATgg+QCcEH6ATgg/QCcEH6MQog+8HrwDmb5TB94NXAPM3yuADMH+CD9AJwQfohOADdELwAToh+ACdEHyATgg+QCdGGXw/aQswf6MMvp+0BZi/UQYfgPkTfIBOCD5AJwQfoBOCD9AJwQfohOADdELwAToh+ACdGGXwvbUCwPyNMvjeWgFg/kYZfADmT/ABOiH4AJ0QfIBOCD5AJwQfoBOCD9AJwQfohOADdELwAToh+ACdEHyATgg+QCdGGXxvjwwwf6MMvrdHBpi/UQYfgPkTfIBOCD5AJwQfoBOCD9AJwQfohOADdELwAToh+ACdEHyATgg+QCcEH6ATgg/QCcEH6ITgA3RC8AE6Mcrg+41XAPM3yuD7jVcA8zfK4AMwf4IP0AnBB+iE4AN0QvABOnHP0APATnL2wpWcOncpV6+t5MDexZw4ejhPHDk49FgwE8GHGZ29cCUnz1zMyvUbSZIr11Zy8szFJBF9dgSXdGBGp85dei32t6xcv5FT5y4NNBFsjODDjK5eW9nQcRgbwYcZHdi7uKHjMDaCDzM6cfRwFvcsvO7Y4p6FnDh6eKCJYGM8aQszuvXErFfpsFMJPmzAE0cOCjw7lks6AJ0QfIBOCD5AJwQfoBOCD9AJwQfohOADdELwAToh+ACdEHyATgg+QCdGGfyqOlZVp5eXl4ceBWDXGGXwW2vPtNaOLy0tDT0KwK4xyuADMH+CD9AJwQfohOADdMJvvAIYibMXrtzVX6Ep+AAjcPbClZw8czEr128kSa5cW8nJMxeTZG7Rd0kHYAROnbv0WuxvWbl+I6fOXZrbfQg+wAhcvbayoeObIfgAI3Bg7+KGjm+G4AOMwImjh7O4Z+F1xxb3LOTE0cNzuw9P2gKMwK0nZr1KB6ADTxw5ONfAT3NJB6ATgg/QCcEH6ITgA3RC8AE6Ua21oWdYV1V9JcmXNvnl+5J8dY7jzIu5NsZcG2OujdmNc31Xa23/WidGHfytqKrzrbVHhp5jmrk2xlwbY66N6W0ul3QAOiH4AJ3YzcE/PfQA6zDXxphrY8y1MV3NtWuv4QPwerv5O3wAVhF8gE7s6OBX1QNV9bdV9UJVfaGqfm2NNVVVv1dVL1bVv1TVwyOZ621VtVxVn5t8/PY2zPWtVfVPVfXPk7l+Z401Q+zXLHNt+36tuu+FqrpQVc+ucW7b92vGuQbZr6p6uaouTu7z/BrnB9mvGeYaar/2VtVTVfXFSS/eMnV+vvvVWtuxH0nuS/Lw5Pabkvxbku+dWvMTST6VpJI8luTTI5nrbUme3eb9qiRvnNzek+TTSR4bwX7NMte279eq+/6NJB9b6/6H2K8Z5xpkv5K8nGTfbc4Psl8zzDXUfn04yS9Obt+bZO/d3K8d/R1+a+3LrbXPTm7/R5IXkky/mfQ7k3yk3fSPSfZW1X0jmGvbTfbgPyef7pl8TD9rP8R+zTLXIKrq/iQ/meSD6yzZ9v2aca6xGmS/xqiqvi3JW5N8KElaa//TWrs2tWyu+7Wjg79aVR1KciQ3vztc7WCSV1Z9fjnbGN/bzJUkb5lcxvhUVX3fNs2zUFWfS/Jqkr9urY1iv2aYKxlgv5K8P8lvJvnfdc4P9fh6f24/VzLMfrUkf1VVz1fV8TXOD7Vfd5or2f79enOSryT5k8mluQ9W1Rum1sx1v3ZF8KvqjUn+Ismvt9a+Pn16jS/Zlu8e7zDXZ3PzPS9+IMnvJzm7HTO11m601n4wyf1JHq2q759aMsh+zTDXtu9XVb0jyauttedvt2yNY3d1v2aca5DHV5LHW2sPJ/nxJL9cVW+dOj/U38c7zTXEft2T5OEkf9RaO5Lkv5K8d2rNXPdrxwe/qvbkZlQ/2lo7s8aSy0keWPX5/UmuDj1Xa+3rty5jtNaeS7Knqvbd7blW3f+1JH+X5O1TpwbZr1vWm2ug/Xo8yU9V1ctJPp7kh6rqz6bWDLFfd5xrqMdXa+3q5J+vJvlkkkenlgzy+LrTXAPt1+Ukl1f93+xTufkfgOk1c9uvHR38qqrcvP71Qmvtd9dZ9nSSn5882/1YkuXW2peHnquqvnOyLlX1aG7+u/jaXZ5rf1XtndxeTPIjSb44tWyI/brjXEPsV2vtZGvt/tbaoSRPJvmb1trPTi3b9v2aZa6BHl9vqKo33bqd5MeSfH5q2RCPrzvONdDj69+TvFJVhyeHfjjJv04tm+t+7fRfYv54kp9LcnFy/TdJfivJg0nSWvtAkudy85nuF5P8d5J3jWSun07yS1X1jSQrSZ5sk6fl76L7kny4qhZy8wH9idbas1X1nlVzDbFfs8w1xH6taQT7NctcQ+zXdyT55KSb9yT5WGvtL0ewX7PMNdTj61eTfLSq7k3yUpJ33c398tYKAJ3Y0Zd0AJid4AN0QvABOiH4AJ0QfIBOCD5AJwQfoBP/B8LAqH2uFIYNAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "errors = [-0.3834587823958312, -0.025847683970086854, -0.017408907758388492]\n",
+    "errors_array = np.abs(np.array(errors))\n",
+    "plt.scatter(np.arange(2, 8, 2), errors_array, label='Error')\n",
+    "plt.axhline(y=0, color='r', linestyle='--')\n",
+    "plt.yscale('log')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 84,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "FCI energy for 2:  -0.4999999999999998 ; error:  -0.05685281944005449\n",
+      "FCI energy for 4:  -0.4999999999999991 ; error:  -0.056852819440053826\n",
+      "FCI energy for 6:  -0.46712927295533246 ; error:  -0.023982092395387178\n"
+     ]
+    }
+   ],
+   "source": [
+    "def generate_inds(value, p, q, r, s):\n",
+    "    \"\"\"\n",
+    "    Generate all the indices for the 4 different terms in the 2-body hamiltonian\n",
+    "    \"\"\"\n",
+    "    res = []\n",
+    "    res.append((value, p, q, r, s))\n",
+    "    res.append((value, r, s, p, q))\n",
+    "    # res.append((-value, p, s, r, q))\n",
+    "    # res.append((-value, r, q, p, s))\n",
+    "\n",
+    "    res.append((value, p, q, s, r))\n",
+    "    res.append((value, q, p, r, s))\n",
+    "    res.append((value, q, p, s, r))\n",
+    "\n",
+    "    # permutation symmetries\n",
+    "    res.append((value, s, r, p, q))\n",
+    "    res.append((value, r, s, q, p))\n",
+    "    res.append((value, s, r, q, p))\n",
+    "\n",
+    "\n",
+    "    return res\n",
+    "\n",
+    "for n_sites in range(2, 8, 2):\n",
+    "\n",
+    "    J_xy = 1\n",
+    "    J_z = 1\n",
+    "    h = np.zeros((n_sites, n_sites))\n",
+    "    v = np.zeros((n_sites, n_sites, n_sites, n_sites))\n",
+    "\n",
+    "    for i in range(n_sites):\n",
+    "        j = i+1\n",
+    "        if j == n_sites:\n",
+    "            j = 0\n",
+    "\n",
+    "        h[i, i] = -J_z/2\n",
+    "\n",
+    "    # populating 2body terms \n",
+    "    for i in range(n_sites):\n",
+    "        j = i+1\n",
+    "        if j == n_sites:\n",
+    "            j = 0\n",
+    "\n",
+    "        v[j, j, i, i] = J_z/4\n",
+    "        v[i, i, j, j] = J_z/4\n",
+    "        \n",
+    "        v[j, i, j, i] = J_xy/2\n",
+    "        v[i, j, i, j] = J_xy/2\n",
+    "\n",
+    "        #new terms\n",
+    "        # v[j, i, i, j] = J_xy/2\n",
+    "        # v[i, j, j, i] = J_xy/2\n",
+    "\n",
+    "\n",
+    "    e_0 = J_z/4*n_sites\n",
+    "\n",
+    "    # solve fullci problem\n",
+    "    e, fcivec = fci.direct_spin0.kernel(1*h, 1*v, n_sites, n_sites, nroots=1,\n",
+    "                                        max_memory=10000, pspace_size=20000)\n",
+    "    e_exact = 0.25-np.log(2)\n",
+    "    print(f\"FCI energy for {n_sites}: \", (e+e_0)/(n_sites), \"; error: \", (e+e_0)/(n_sites)-e_exact)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 85,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "FCI energy:  -0.46712927295533246\n"
+     ]
+    }
+   ],
+   "source": [
+    "from scipy.sparse import diags\n",
+    "# building the hamiltonian using matrices\n",
+    "N_sites = 6\n",
+    "J_ax = diags([np.ones(N_sites-1),\n",
+    "              np.ones(N_sites-1)], [-1, 1], format='lil')\n",
+    "J_ax[0, -1] = J_ax[-1, 0] = 1\n",
+    "J_ax = J_ax.toarray()/2 # dividing by 2 to enforce sum_q {J_pq} = J_z\n",
+    "mu = np.zeros(N_sites)\n",
+    "\n",
+    "J_eq = J_ax.copy()\n",
+    "\n",
+    "\n",
+    "h0 = 0.25*np.sum(J_ax) - 0.5*np.sum(mu-np.diag(J_eq))\n",
+    "h1 = np.zeros((N_sites, N_sites))\n",
+    "for p in range(N_sites):\n",
+    "    h1[p, p] = 0.5*(mu[p]-np.sum(J_ax[p, :]))\n",
+    "\n",
+    "h2 = np.zeros((N_sites, N_sites, N_sites, N_sites))\n",
+    "for p in range(N_sites):\n",
+    "    for q in range(N_sites):\n",
+    "        h2[p, q, p, q] = J_eq[p, q] * 2 #summing over spin. In here we don't have aaaa and bbbb parts: only aabb and bbaa\n",
+    "        h2[p, p, q, q] = 0.25*J_ax[p, q] * 4 # summing over spin\n",
+    "\n",
+    "# solve the fullci problem\n",
+    "e_final, fcivec_final = fci.direct_spin0.kernel(h1,0.5*h2, N_sites, N_sites, nroots=1, max_memory=10000)\n",
+    "print (\"FCI energy: \", (e_final+h0)/N_sites)\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 70,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.0"
+      ]
+     },
+     "execution_count": 70,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.sum(v-h2/2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([1., 1., 1., 1., 1., 1.])"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.ones(N_sites)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "base",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/moha/api.py
+++ b/moha/api.py
@@ -29,6 +29,17 @@ class HamiltonianAPI(ABC):
         """
         max_site = 0
         atoms_sites_lst = []
+
+        # check if self.connectivity is a matrix
+        # if so, put assign it to self.connectivity_matrix
+        # and set the atom_types to None
+        if isinstance(self.connectivity, np.ndarray):
+            self.connectivity_matrix = csr_matrix(self.connectivity)
+            self.atom_types = None
+            self.n_sites = self.connectivity_matrix.shape[0]
+
+            return None, self.connectivity_matrix
+        
         for atom1, atom2, bond in self.connectivity:
             atom1_name, site1 = get_atom_type(atom1)
             atom2_name, site2 = get_atom_type(atom2)

--- a/moha/api.py
+++ b/moha/api.py
@@ -6,7 +6,7 @@ from typing import TextIO
 
 import numpy as np
 
-from scipy.sparse import csr_matrix, lil_matrix
+from scipy.sparse import csr_matrix, lil_matrix, diags
 
 from .utils import convert_indices, get_atom_type
 
@@ -174,8 +174,7 @@ class HamiltonianAPI(ABC):
 
         # Return if target dim is not 2 or 4.
         else:
-            print("Target output dimension must be either 2 or 4.")
-            return
+            raise ValueError("Target output dimension must be either 2 or 4.")
 
     def to_spatial(self, sym: int, dense: bool, nbody: int):
         r"""
@@ -233,19 +232,8 @@ class HamiltonianAPI(ABC):
         spatial_int = spatial_int.tocsr()
 
         if dense:
-            if isinstance(
-                    spatial_int, csr_matrix
-            ):  # FixMe make sure that this works for every system
-                spatial_int = spatial_int.toarray()
-                spatial_int = np.reshape(
-                    spatial_int, (self.n_sites,
-                                  self.n_sites,
-                                  self.n_sites,
-                                  self.n_sites)
-                )
-            else:
-                spatial_int = self.to_dense(spatial_int,
-                                            dim=4 if nbody == 2 else 1)
+            spatial_int = self.to_dense(spatial_int,
+                                        dim=4 if nbody == 2 else 2)
         return spatial_int
 
     def to_spinorbital(self, integral: np.ndarray, sym=1, dense=False):

--- a/moha/api.py
+++ b/moha/api.py
@@ -39,7 +39,7 @@ class HamiltonianAPI(ABC):
             self.n_sites = self.connectivity_matrix.shape[0]
 
             return None, self.connectivity_matrix
-        
+
         for atom1, atom2, bond in self.connectivity:
             atom1_name, site1 = get_atom_type(atom1)
             atom2_name, site2 = get_atom_type(atom2)
@@ -205,21 +205,27 @@ class HamiltonianAPI(ABC):
         spatial_int: scipy.sparce.csr_matrix or np.ndarray
             one-/two-body integrals in spatial basis
 
-        
+
         Notes
         -----
         Given the one- or two-body Hamiltonian matrix terms,
         :math:`h_{i,j}` and :math:`g_{ij,kl}` respectively,
-        we populate the spatial integrals by calcualting __average__ over the spin-orbitals
+        we populate the spatial integrals by calcualting __average__ over the
+        spin-orbitals
 
-        Specifically, for the one-body integrals, we have:
-        :math:`h_{pq} = 0.25*(h_{pq}^{aa} + h_{pq}^{bb} + h_{pq}^{ab} + h_{pq}^{ba}) = h_{pq}^{aa} = h_{pq}^{bb}`
-        Therefore, the one-body integrals in the spatial basis are the same as the aa part of 
+        Specifically, for the one-body integrals,
+        we have:
+        :math:`h_{pq} = 0.25*(h_{pq}^{aa} + h_{pq}^{bb} + h_{pq}^{ab}
+        + h_{pq}^{ba}) = h_{pq}^{aa} = h_{pq}^{bb}`
+        Therefore, the one-body integrals in the spatial basis
+        are the same as the aa part of
         one-body integrals in the spin-orbital basis.
 
         For the two-body integrals, we have:
-        :math:`v_{pqrs} = 0.25*(v_{pqrs}^{aaaa} + v_{pqrs}^{bbbb} + v_{pqrs}^{abab} + v_{pqrs}^{baba})`
-        Assuming that :math:`v_{pqrs}^{abab} = v_{pqrs}^{baba}` and :math:`v_{pqrs}^{aaaa} = v_{pqrs}^{bbbb}`
+        :math:`v_{pqrs} = 0.25*(v_{pqrs}^{aaaa} + v_{pqrs}^{bbbb} +
+        v_{pqrs}^{abab} + v_{pqrs}^{baba})`
+        Assuming that :math:`v_{pqrs}^{abab} = v_{pqrs}^{baba}` and
+        :math:`v_{pqrs}^{aaaa} = v_{pqrs}^{bbbb}`
         :math:`v_{pqrs} = 0.5*(v_{pqrs}^{aaaa} + v_{pqrs}^{abab})`
         """
         # Assumption: spatial components of alpha and beta
@@ -240,11 +246,11 @@ class HamiltonianAPI(ABC):
                                            p, p + self.n_sites)
                 spatial_int[pp, pp] = integral[(pp_, pp_)]
                 for q in range(p+1, self.n_sites):
-                    # v_pqpq = 0.5*Gamma_pqpq_aa = 0.5*Gamma_pqpq_bb 
+                    # v_pqpq = 0.5*Gamma_pqpq_aa = 0.5*Gamma_pqpq_bb
                     pq, pq = convert_indices(self.n_sites, p, q, p, q)
                     pq_, pq_ = convert_indices(n, p, q, p, q)
                     spatial_int[pq, pq] = 0.5 * integral[pq_, pq_]
-                    # v_pqpq += 0.5*Gamma_pqpq_ab 
+                    # v_pqpq += 0.5*Gamma_pqpq_ab
                     # assuming that Gamma_pqpq_ab = Gamma_pqpq_ba
                     pq_, pq_ = convert_indices(n,
                                                p, q + self.n_sites,

--- a/moha/api.py
+++ b/moha/api.py
@@ -415,6 +415,8 @@ def expand_sym(sym, integral, nbody):
     else:
         # getting nonzero elements from the 2d _sparse_ array
         pq_array, rs_array = integral.nonzero()
+        # getting the size of the corresponding 4d array
+        n = int(np.sqrt(integral.shape[0]))
 
         for pq, rs in zip(pq_array, rs_array):
             p, q, r, s = convert_indices(n, pq, rs)

--- a/moha/hamiltonians.py
+++ b/moha/hamiltonians.py
@@ -193,7 +193,7 @@ class HamPPP(HamiltonianAPI):
             if basis == "spatial basis" and \
                     self.gamma.shape == (n_sp, n_sp):
                 zeros_block = np.zeros((n_sp, n_sp))
-                gamma = np.vstack(
+                self.gamma = np.vstack(
                     [np.hstack([self.gamma, zeros_block]),
                      np.hstack([zeros_block, self.gamma])]
                 )
@@ -201,20 +201,20 @@ class HamPPP(HamiltonianAPI):
                 for q in range(n_sp):
                     if p != q:
                         i, j = convert_indices(Nv, p, q, p, q)
-                        v[i, j] = 0.5 * gamma[p, q]
+                        v[i, j] = 0.5 * self.gamma[p, q]
 
                         i, j = convert_indices(Nv, p, q + n_sp, p, q + n_sp)
-                        v[i, j] = 0.5 * gamma[p, q + n_sp]
+                        v[i, j] = 0.5 * self.gamma[p, q + n_sp]
 
                         i, j = convert_indices(Nv, p + n_sp, q, p + n_sp, q)
-                        v[i, j] = 0.5 * gamma[p + n_sp, q]
+                        v[i, j] = 0.5 * self.gamma[p + n_sp, q]
 
                         i, j = convert_indices(Nv,
                                                p + n_sp,
                                                q + n_sp,
                                                p + n_sp,
                                                q + n_sp)
-                        v[i, j] = 0.5 * gamma[p + n_sp, q + n_sp]
+                        v[i, j] = 0.5 * self.gamma[p + n_sp, q + n_sp]
 
         v = v.tocsr()
         self.two_body = expand_sym(sym, v, 2)

--- a/moha/hamiltonians.py
+++ b/moha/hamiltonians.py
@@ -377,7 +377,7 @@ class HamHeisenberg(HamiltonianAPI):
         mu: np.ndarray
             Zeeman term
         J_eq: np.ndarray
-            J equatorial term            
+            J equatorial term
         J_ax: np.ndarray
             J axial term
         n_sites: int
@@ -399,12 +399,12 @@ class HamHeisenberg(HamiltonianAPI):
             if isinstance(J_eq, np.ndarray) and \
                isinstance(J_ax, np.ndarray) and \
                J_eq.shape == J_ax.shape:
-                
+
                 self.n_sites = J_eq.shape[0]
                 self.J_eq = J_eq
                 self.J_ax = J_ax
             else:
-                raise TypeError("J_eq and J_ax should be numpy arrays of the same shape")
+                raise TypeError("J_eq and J_ax should be numpy arrays of the same shape")  # noqa: E501
 
         self.mu = np.array(mu)
         self.n_sites = n_sites
@@ -422,7 +422,7 @@ class HamHeisenberg(HamiltonianAPI):
         zero_energy: float
         """
         zero_energy = -0.5 * np.sum(self.mu - np.diag(self.J_eq)) \
-                     + 0.25 * np.sum(self.J_ax)/2 # divide by 2 to avoid double counting
+            + 0.25 * np.sum(self.J_ax)/2  # divide by 2 to avoid double counting # noqa: E501
         return zero_energy
 
     def generate_one_body_integral(self,
@@ -453,24 +453,32 @@ class HamHeisenberg(HamiltonianAPI):
         elif basis == "spinorbital basis":
             if self.J_ax.shape != (2 * self.n_sites, 2 * self.n_sites) and \
                     self.J_ax.shape == (self.n_sites, self.n_sites):
-                
-                J_ax = np.hstack([np.vstack([self.J_ax, np.zeros((self.n_sites, self.n_sites))]),
-                                  np.vstack([np.zeros((self.n_sites, self.n_sites)), self.J_ax])])
+
+                J_ax = np.hstack([np.vstack([self.J_ax,
+                                             np.zeros((self.n_sites,
+                                                       self.n_sites))]),
+                                  np.vstack([np.zeros((self.n_sites,
+                                                       self.n_sites)),
+                                             self.J_ax])])
             else:
                 raise TypeError("J_ax matrix has wrong basis")
             if self.J_eq.shape != (2 * self.n_sites, 2 * self.n_sites) and \
                     self.J_eq.shape == (self.n_sites, self.n_sites):
-                
-                J_eq = np.hstack([np.vstack([self.J_eq, np.zeros((self.n_sites, self.n_sites))]),
-                                  np.vstack([np.zeros((self.n_sites, self.n_sites)), self.J_eq])])
+
+                J_eq = np.hstack([np.vstack([self.J_eq,
+                                             np.zeros((self.n_sites,
+                                                       self.n_sites))]),
+                                  np.vstack([np.zeros((self.n_sites,
+                                                       self.n_sites)),
+                                             self.J_eq])])
             else:
                 raise TypeError("J_eq matrix has wrong basis")
-            
-            if self.mu.shape != (2 * self.n_sites,) and self.mu.shape == (self.n_sites,):
+
+            if self.mu.shape != (2 * self.n_sites,) and\
+               self.mu.shape == (self.n_sites,):
                 mu = np.hstack([self.mu, self.mu])
             else:
                 raise TypeError("mu array has wrong basis")
-
 
         one_body_term = 0.5 * diags(mu - np.diag(J_eq) -
                                     (np.sum(J_ax, axis=1)-np.diag(J_ax))/2,

--- a/moha/hamiltonians.py
+++ b/moha/hamiltonians.py
@@ -388,6 +388,7 @@ class HamHeisenberg(HamiltonianAPI):
         if connectivity:
             self.n_sites = connectivity.shape[0]
             # if J_eq and J_ax are floats then convert them to numpy arrays
+            # by multiplying with connectivity matrix
             if isinstance(J_eq, (int, float)):
                 self.J_eq = J_eq * connectivity
                 self.J_ax = J_ax * connectivity

--- a/moha/hamiltonians.py
+++ b/moha/hamiltonians.py
@@ -440,14 +440,31 @@ class HamHeisenberg(HamiltonianAPI):
 
             J_ax = self.J_ax
             J_eq = self.J_eq
+            mu = self.mu
 
         elif basis == "spinorbital basis":
-            if self.J_ax.shape != (2 * self.n_sites, 2 * self.n_sites):
+            if self.J_ax.shape != (2 * self.n_sites, 2 * self.n_sites) and \
+                    self.J_ax.shape == (self.n_sites, self.n_sites):
+                
+                J_ax = np.hstack([np.vstack([self.J_ax, np.zeros((self.n_sites, self.n_sites))]),
+                                  np.vstack([np.zeros((self.n_sites, self.n_sites)), self.J_ax])])
+            else:
                 raise TypeError("J_ax matrix has wrong basis")
-            if self.J_eq.shape != (2 * self.n_sites, 2 * self.n_sites):
+            if self.J_eq.shape != (2 * self.n_sites, 2 * self.n_sites) and \
+                    self.J_eq.shape == (self.n_sites, self.n_sites):
+                
+                J_eq = np.hstack([np.vstack([self.J_eq, np.zeros((self.n_sites, self.n_sites))]),
+                                  np.vstack([np.zeros((self.n_sites, self.n_sites)), self.J_eq])])
+            else:
                 raise TypeError("J_eq matrix has wrong basis")
+            
+            if self.mu.shape != (2 * self.n_sites,) and self.mu.shape == (self.n_sites,):
+                mu = np.hstack([self.mu, self.mu])
+            else:
+                raise TypeError("mu array has wrong basis")
 
-        one_body_term = 0.5 * diags(self.mu - np.diag(J_eq) -
+
+        one_body_term = 0.5 * diags(mu - np.diag(J_eq) -
                                     (np.sum(J_ax, axis=1)-np.diag(J_ax))/2,
                                     format="csr")
 

--- a/moha/test/test.py
+++ b/moha/test/test.py
@@ -152,6 +152,7 @@ def test_ppp_api():
     assert h.shape[0] == 6
     assert v.shape[0] == 6
 
+
 def test_api_input():
     r"""Test the input of the API."""
     norb = 6
@@ -171,9 +172,10 @@ def test_api_input():
     v = ham.generate_two_body_integral(sym=1,
                                        basis='spinorbital basis',
                                        dense=True)
-    
+
     assert h.shape[0] == 12
     assert v.shape[0] == 12
+
 
 def test_spin_spatial_conversion():
     r"""Test the conversion between spin and spatial basis."""
@@ -193,7 +195,7 @@ def test_spin_spatial_conversion():
     v = ham.generate_two_body_integral(sym=4,
                                        basis='spinorbital basis',
                                        dense=True)
-    
+
     h = ham.to_spatial(sym=1, dense=True, nbody=1)
     v = ham.to_spatial(sym=4, dense=True, nbody=2)
 
@@ -206,5 +208,3 @@ def test_spin_spatial_conversion():
         h2[i, i, i, i] = 1
     np.testing.assert_allclose(h, h1)
     np.testing.assert_allclose(v, h2)
-
-    

--- a/moha/test/test.py
+++ b/moha/test/test.py
@@ -151,3 +151,60 @@ def test_ppp_api():
 
     assert h.shape[0] == 6
     assert v.shape[0] == 6
+
+def test_api_input():
+    r"""Test the input of the API."""
+    norb = 6
+    connectivity = np.zeros((norb, norb))
+    for i in range(norb - 1):
+        connectivity[i, i + 1] = 1
+        connectivity[i + 1, i] = 1
+    connectivity[-1, 0] = 1
+
+    u_matrix = np.ones(norb)
+    g_matrix = np.arange(36).reshape((norb, norb))
+    charges = np.ones(norb)
+
+    ham = HamPPP(connectivity, alpha=0., beta=-2.5, u_onsite=u_matrix,
+                 gamma=g_matrix, charges=charges)
+    h = ham.generate_one_body_integral(basis='spinorbital basis', dense=True)
+    v = ham.generate_two_body_integral(sym=1,
+                                       basis='spinorbital basis',
+                                       dense=True)
+    
+    assert h.shape[0] == 12
+    assert v.shape[0] == 12
+
+def test_spin_spatial_conversion():
+    r"""Test the conversion between spin and spatial basis."""
+    norb = 4
+    connectivity = np.zeros((norb, norb))
+    for i in range(norb - 1):
+        connectivity[i, i + 1] = 1
+        connectivity[i + 1, i] = 1
+    connectivity[-1, 0] = 1
+    connectivity[0, -1] = 1
+
+    u_matrix = np.ones(norb)
+
+    beta = -2.5
+    ham = HamHub(connectivity, alpha=0., beta=beta, u_onsite=u_matrix)
+    h = ham.generate_one_body_integral(basis='spinorbital basis', dense=True)
+    v = ham.generate_two_body_integral(sym=4,
+                                       basis='spinorbital basis',
+                                       dense=True)
+    
+    h = ham.to_spatial(sym=1, dense=True, nbody=1)
+    v = ham.to_spatial(sym=4, dense=True, nbody=2)
+
+    h1 = np.array([[0., beta, 0., beta],
+                   [beta, 0., beta, 0.],
+                   [0., beta, 0., beta],
+                   [beta, 0., beta, 0.]])
+    h2 = np.zeros((4, 4, 4, 4))
+    for i in range(4):
+        h2[i, i, i, i] = 1
+    np.testing.assert_allclose(h, h1)
+    np.testing.assert_allclose(v, h2)
+
+    

--- a/moha/utils.py
+++ b/moha/utils.py
@@ -157,3 +157,24 @@ def expand_sym(sym, integral, nbody):
                 integral[sp, qr] = integral[qp, sr]
                 integral[qr, sp] = integral[sr, qp]
     return integral
+
+def fill_o2(o2):
+    """
+    Fill the 2-body matrix with the missing elements.
+
+    Parameters
+    ----------
+    o2: np.ndarray
+        4-D array, the two-body integrals
+
+    Returns
+    -------
+    o2: np.ndarray
+        4d array with the symmetry 1
+    """
+    # loop over nonzero elements
+    for i, j, k, l in np.nonzero(o2):
+        o2[j, i, k, l] = - o2[i, j, k, l]
+        o2[j, i, l, k] = o2[i, j, k, l]
+        o2[i, j, l, k] = -o2[i, j, k, l]
+    return o2

--- a/moha/utils.py
+++ b/moha/utils.py
@@ -158,6 +158,7 @@ def expand_sym(sym, integral, nbody):
                 integral[qr, sp] = integral[sr, qp]
     return integral
 
+
 def fill_o2(o2):
     """
     Fill the 2-body matrix with the missing elements.

--- a/moha/utils.py
+++ b/moha/utils.py
@@ -23,7 +23,7 @@ def convert_indices(N, *args):
     if len(args) == 4:
         # Check if indices are right
         for elem in args:
-            if not isinstance(elem, int):
+            if not isinstance(elem, int) and not isinstance(elem, np.int64):
                 raise TypeError("Wrong indices")
             if elem >= N:
                 raise TypeError("index is greater than size of the matrix")
@@ -37,7 +37,7 @@ def convert_indices(N, *args):
     elif len(args) == 2:
         # check indices
         for elem in args:
-            if not isinstance(elem, int):
+            if not isinstance(elem, int) and not isinstance(elem, np.int32):
                 raise TypeError("Wrong indices")
             if elem >= N**2:
                 raise TypeError("index is greater than size of the matrix")


### PR DESCRIPTION
Added XXZ Heisenberg model.

Alongside made few changes in api:

1. Change logic of connectivity matrix:
    If connectivity matrix is provided, then J_ax and J_eq has to be floats. Arrays are computed by multiplication of provided floats with connectivity
    If connectivity matrix is not provided, then J_ax and J_eq has to by numpy arrays of the same size

2. For the PPP Hamiltonian, `gamma` matrix has to be provided in spatial basis, not spin orbital basis. Otherwise it does not make sense

3. Added conversion of term [pp, qq] when converting to spatial format. It appears in Heisenberg model, and wasn't supported before. 