### PR TITLE
Support for ChatGPT input commands

### DIFF
--- a/scripts/chatgpt_to_moha.py
+++ b/scripts/chatgpt_to_moha.py
@@ -1,0 +1,171 @@
+from toml_to_moha import *
+import sys
+sys.path.insert(0, '../')
+
+import json
+from openai import OpenAI
+
+# uncomment to set your API key from text file
+# with open('path/to/api_key.txt', 'r') as file:
+#     api_key = file.read().replace('\n', '')
+
+# Choose ChatGPT model version and setup client
+GPT_MODEL = "gpt-3.5-turbo"
+client = OpenAI()
+
+# Define model parameters and common descriptions
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_system",
+            "description": "Get the system parameters.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "moltype": {
+                        "type": "string",
+                        "enum": ["1d"],
+                        "description": "The site structure on which the model is defined.",
+                    },
+                    "bc": {
+                        "type": "string",
+                        "enum": ["open", "periodic"],
+                        "description": "The boundary conditions. Prefer open if not specified.",
+                    },
+                    "norb": {
+                        "type": "integer",
+                        "description": "The number of spin-orbitals.",
+                    },
+                    "nelec": {
+                        "type": "integer",
+                        "description": "The number of electrons occupying some of the spin-orbitals.",
+                    },
+                    "symmetry": {
+                        "type": "integer",
+                        "enum": [1, 2, 4, 8],
+                        "description": "Symmetry of the two-electron integrals. Prefer 4 if not specified.",
+                    }
+                },
+            },
+        }
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_model_hamiltonian",
+            "description": "Get the model hamiltonian",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "hamiltonian": {
+                        "type": "string",
+                        "enum": ["PPP", "Hubbard", "Huckel", "Heisenberg", "Ising", "RG"],
+                        "description": "The name of the model, e.g. Hubbard.",
+                    },
+                    "basis": {
+                        "type": "string",
+                        "enum": ["spatial basis", "spinorbital basis"],
+                        "description": "The basis type. Prefer spatial basis if not specified.",
+                    },
+                    "alpha": {
+                        "type": "number",
+                        "description": "The on-site interaction strength. \
+                                        Assume all sites are equivalent if not specified. \
+                                        Relevant to PPP, Hubbard, Huckel.",
+                    },
+                    "beta": {
+                        "type": "number",
+                        "description": "The resonance energy, hopping amplitude. \
+                                        Assume all bonds are equivalent if not specified. \
+                                        Relevant to PPP, Hubbard, Huckel.",
+                    },
+                    "u_onsite": {
+                        "type": "number",
+                        "description": "The on-site Coulomb interaction. \
+                                        Assume all sites are equivalent if not specified. \
+                                        Relevant to PPP, Hubbard.",
+                    },
+                    "gamma": {
+                        "type": "number",
+                        "description": "Parameter that specifies long-range Coulomb interaction. \
+                                        Relevant to PPP.",
+                    },
+                    "mu": {
+                        "type": "number",
+                        "description": "Zeeman term or external magnetic field. \
+                                        Relevant to Ising, RG, Heisenberg.",
+                    },
+                    "J_eq": {
+                        "type": "number",
+                        "description": "Coupling between neighbouring S_x and S_y spin components. \
+                                        It enters the hamiltonian as J_eq*(S^x_iS^x_j + S^y_iS^y_j). \
+                                        Relevant to RG, Heisenberg.",
+                    },
+                    "J_ax": {
+                        "type": "number",
+                        "description": "Coupling between neighbouring S_z spin components. \
+                                        It enters the hamiltonian as J_ax*(S^z_iS^z_j). \
+                                        Relevant to Ising, Heisenberg.",
+                    },
+                },
+                "required": ["hamiltonian"],
+            },
+        }
+    },
+]
+
+def chat_completion_request(messages, tools=None, tool_choice=None, model=GPT_MODEL):
+    try:
+        response = client.chat.completions.create(
+            model=model,
+            messages=messages,
+            tools=tools,
+            tool_choice=tool_choice,
+        )
+        return response
+    except Exception as e:
+        print("Unable to generate ChatCompletion response")
+        print(f"Exception: {e}")
+        return e
+
+def chatgpt_to_ham(input_string):
+    '''
+    Function for generating hamiltonian from toml file.
+    Prints integrals to output file if specified in toml_file.
+
+    Parameters
+        ----------
+        input_string: str
+            user input ChatGPT command
+
+    Returns
+        -------
+        moha.Ham
+    '''
+
+    messages = []
+    messages.append({"role": "system", "content":
+                     "Set all parameters relevant to specified model. Do not describe the model."})
+    messages.append({"role": "user", "content": input_string})
+    chat_response = chat_completion_request(
+        messages, tools=tools
+    )
+    assistant_message = chat_response.choices[0].message
+    messages.append(assistant_message)
+
+    data = {}
+    if assistant_message.tool_calls[0].function.name == "get_model_hamiltonian":
+        data["model"] = json.loads(assistant_message.tool_calls[0].function.arguments)
+    else:
+        results = f"Error: function {assistant_message.tool_calls[0].function.name} does not exist"
+
+    ham = dict_to_ham(data)
+    print(ham)
+    print(data["model"])
+
+    return ham
+
+if __name__ == '__main__':
+    input_string = input("Tell us to generate a Hamiltonian: ") 
+    ham = chatgpt_to_ham(input_string)


### PR DESCRIPTION
I have created a currently very basic script to support a ChatGPT interface. The script uses all of the methods from toml_to_moha.py and works in a very similar way. However, in this case, the user is asked to input a command describing the hamiltonian that the user would like to generate. Much of this script follows the same pattern as described in the tutorial on the [OpenAI cookbook website](https://cookbook.openai.com/examples/how_to_call_functions_with_chat_models), except instead of asking for the weather, we are asking for model hamiltonians.

Using `py chatgpt_to_moha.py` from within the scripts directory initiates the request for input:
```
py chatgpt_to_moha.py
Tell us to generate a Hamiltonian:
```
 A model hamiltonian object is then generated based on the input.

For example, the generation of a Hubbard hamiltonian may look like this:
```
py .\chatgpt_to_moha.py
Tell us to generate a Hamiltonian: generate the hubbard model with t=1.7 and U=5.2eV
```
Since I have included the lines `print(ham)` and `print(data["model"])` in the chatgpt_to_ham function, the following output is then printed to the terminal:
```
<moha.hamiltonians.HamHub object at 0x0000019AB9820260>
{'hamiltonian': 'hubbard', 'beta': 1.7, 'u_onsite': 5.2, 'basis': 'spatial basis', 'charge': 0.0, 'alpha': 0.0, 'mu': 0.0, 'J_eq': 0.0, 'J_ax': 0.0}
```
which is exactly the requested hamiltonian object with all defaults set from within the defaults.toml file. We will of course want to modify the ChatGPT functions and descriptions to incorporate better functionality, but the current chatgpt_to_moha.py is simply a minimal working script.
