### PR TITLE
Fix two site Heisenberg model

### DIFF
--- a/moha/hamiltonians.py
+++ b/moha/hamiltonians.py
@@ -521,8 +521,14 @@ class HamHeisenberg(HamiltonianAPI):
             else:
                 raise TypeError("mu array has wrong basis")
 
+        # sum of J_ax_ij for j>i
+        sum_Jij = (np.sum(J_ax, axis=1) - np.diag(J_ax)) / 2
+        # if only two sites are present, then no need to devide by 2 two avoid double counting
+        if sum_Jij.shape[0] == 2:
+            sum_Jij *= 2
+
         one_body_term = 0.5 * diags(mu - np.diag(J_eq) -
-                                    (np.sum(J_ax, axis=1) - np.diag(J_ax)) / 2,
+                                    sum_Jij,
                                     format="csr")
 
         self.one_body = one_body_term

--- a/moha/hamiltonians.py
+++ b/moha/hamiltonians.py
@@ -523,9 +523,10 @@ class HamHeisenberg(HamiltonianAPI):
 
         # sum of J_ax_ij for j>i
         sum_J_ax_ij = (np.sum(J_ax, axis=1) - np.diag(J_ax)) / 2
-        # if only two sites are present, then no need to devide by 2 two avoid double counting
-        if sum_J_axij.shape[0] == 2:
-            sum_J_axij *= 2
+        # if only two sites are present,
+        # then no need to devide by 2 two avoid double counting
+        if sum_J_ax_ij.shape[0] == 2:
+            sum_J_ax_ij *= 2
 
         one_body_term = 0.5 * diags(mu - np.diag(J_eq) -
                                     sum_J_ax_ij,

--- a/moha/hamiltonians.py
+++ b/moha/hamiltonians.py
@@ -522,13 +522,13 @@ class HamHeisenberg(HamiltonianAPI):
                 raise TypeError("mu array has wrong basis")
 
         # sum of J_ax_ij for j>i
-        sum_Jij = (np.sum(J_ax, axis=1) - np.diag(J_ax)) / 2
+        sum_J_ax_ij = (np.sum(J_ax, axis=1) - np.diag(J_ax)) / 2
         # if only two sites are present, then no need to devide by 2 two avoid double counting
-        if sum_Jij.shape[0] == 2:
-            sum_Jij *= 2
+        if sum_J_axij.shape[0] == 2:
+            sum_J_axij *= 2
 
         one_body_term = 0.5 * diags(mu - np.diag(J_eq) -
-                                    sum_Jij,
+                                    sum_J_ax_ij,
                                     format="csr")
 
         self.one_body = one_body_term


### PR DESCRIPTION
This pull request includes a change to the `generate_one_body_integral` method in the `moha/hamiltonians.py` file. The change introduces a new variable to handle the sum of `J_ax_ij` for `j > i` and adjusts the calculation to avoid double counting when only two sites are present.

Key changes:

* [`moha/hamiltonians.py`](diffhunk://#diff-89a7a34166f612a0f0c4579646364b29d18f255a84f4928081eab7dfa015b6c4R524-R531): Added a new variable `sum_J_ax_ij` to store the sum of `J_ax_ij` for `j > i` and modified the calculation to avoid double counting for two sites.

Notes:

For the case of a two-site Heisenberg model, one of the elements of the one-body term shouldn’t be divided by two. We divide it by two to avoid double counting, but in the case of two sites, there’s nothing to double count. 