### PR TITLE
Fix docstrings for HamIsing and HamRG classes

### DIFF
--- a/moha/hamiltonians.py
+++ b/moha/hamiltonians.py
@@ -393,9 +393,9 @@ class HamHeisenberg(HamiltonianAPI):
     Models spin-1/2 particles on a lattice with the Hamiltonian:\r
 \r
     .. math::\r
-        \hat{H}_{XXZ} = \sum_p (\mu_p^Z - J_{pp}^{\mathrm{eq}}) S_p^Z\r
-        + \sum_{pq} J_{pq}^{\mathrm{ax}} S_p^Z S_q^Z\r
-        + \sum_{pq} J_{pq}^{\mathrm{eq}} (S_p^+ S_q^- + S_p^- S_q^+)\r
+        \hat{H}_{XXZ} = \sum_p (\mu_p^Z - J_{pp}^{\mathrm{eq}}) S_p^Z 
+        + \sum_{pq} J_{pq}^{\mathrm{ax}} S_p^Z S_q^Z 
+        + \sum_{pq} J_{pq}^{\mathrm{eq}} (S_p^+ S_q^- + S_p^- S_q^+)
 \r
     `HamIsing` and `HamRG` are special cases of this class.\r
     """

--- a/moha/hamiltonians.py
+++ b/moha/hamiltonians.py
@@ -388,7 +388,17 @@ class HamHuck(HamHub):
 
 
 class HamHeisenberg(HamiltonianAPI):
-    r"""XXZ Heisenberg Hamiltonian."""
+    r"""XXZ Heisenberg Hamiltonian.\r
+\r
+    Models spin-1/2 particles on a lattice with the Hamiltonian:\r
+\r
+    .. math::\r
+        \hat{H}_{XXZ} = \sum_p (\mu_p^Z - J_{pp}^{\mathrm{eq}}) S_p^Z\r
+        + \sum_{pq} J_{pq}^{\mathrm{ax}} S_p^Z S_q^Z\r
+        + \sum_{pq} J_{pq}^{\mathrm{eq}} (S_p^+ S_q^- + S_p^- S_q^+)\r
+\r
+    `HamIsing` and `HamRG` are special cases of this class.\r
+    """
 
     def __init__(self,
                  mu: np.ndarray,
@@ -608,7 +618,7 @@ class HamIsing(HamHeisenberg):
                  J_ax: np.ndarray,
                  connectivity: np.ndarray = None
                  ):
-        r"""Initialize XXZ Heisenberg Hamiltonian.
+        r"""Initialize Ising Hamiltonian.
 
         Parameters
         ----------
@@ -651,7 +661,7 @@ class HamRG(HamHeisenberg):
                  J_eq: np.ndarray,
                  connectivity: np.ndarray = None
                  ):
-        r"""Initialize XXZ Heisenberg Hamiltonian.
+        r"""Initialize Richardson-Gaudin Hamiltonian.
 
         Parameters
         ----------


### PR DESCRIPTION
## Description
This PR fixes a minor documentation bug in the [HamIsing](cci:2://file:///c:/Users/parth/OneDrive/Desktop/GSOC%2726/ModelHamiltonian/ModelHamiltonian/moha/hamiltonians.py:612:0-652:9) and [HamRG](cci:2://file:///c:/Users/parth/OneDrive/Desktop/GSOC%2726/ModelHamiltonian/ModelHamiltonian/moha/hamiltonians.py:655:0-695:9) classes where the [__init__](cci:1://file:///c:/Users/parth/OneDrive/Desktop/GSOC%2726/ModelHamiltonian/ModelHamiltonian/moha/hamiltonians.py:392:4-450:21) docstrings were incorrectly copied from the [HamHeisenberg](cci:2://file:///c:/Users/parth/OneDrive/Desktop/GSOC%2726/ModelHamiltonian/ModelHamiltonian/moha/hamiltonians.py:389:0-609:54) base class.

### Changes made:
* Updated the [__init__] docstring in [HamIsing] to state `"Initialize Ising Hamiltonian."` instead of `"Initialize XXZ Heisenberg Hamiltonian."`
* Updated the [__init__] docstring in [HamRG] to state `"Initialize Richardson-Gaudin Hamiltonian."` instead of `"Initialize XXZ Heisenberg Hamiltonian."`
* Expanded the class docstring for the base [HamHeisenberg] to include the mathematical formulation of the XXZ Hamiltonian and explicitly mention its relation to the [HamIsing] and [HamRG] subclasses for better clarity.

## Type of change
- [x] Documentation update

## How Has This Been Tested?
This is a documentation-only update. No code logic was modified. Existing tests can be verified using `pytest moha/test/test_Heisenberg.py`.
